### PR TITLE
Simply ConfigManager to only handle reading and writing config files

### DIFF
--- a/src/main/java/com/kwvanderlinde/discordant/core/config/ConfigManager.java
+++ b/src/main/java/com/kwvanderlinde/discordant/core/config/ConfigManager.java
@@ -3,8 +3,6 @@ package com.kwvanderlinde.discordant.core.config;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.kwvanderlinde.discordant.mc.discord.DiscordConfig;
-import com.kwvanderlinde.discordant.mc.discord.Discordant;
-import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -12,63 +10,45 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 public class ConfigManager {
+    private final Path configRoot;
+    private final Path mainConfigPath;
 
-    public void genDiscordLinkSettings() {
-        if (!Files.exists(Paths.get("./config/discordant/config.json"))) {
+    public ConfigManager(Path configRoot) {
+        this.configRoot = configRoot;
+        this.mainConfigPath = configRoot.resolve("config.json");
+    }
+
+    public Path getConfigRoot() {
+        return configRoot;
+    }
+
+    public void ensureConfigStructure() throws IOException {
+        if (!Files.exists(mainConfigPath)) {
             String gson = new GsonBuilder().setPrettyPrinting().create().toJson(new DiscordConfig());
-            File file = new File("./config/discordant/config.json");
+
+            File file = mainConfigPath.toFile();
             fileWriter(file, gson);
         }
-    }
 
-    public void writeCurrentConfigInstance() {
-        String gson = new GsonBuilder().setPrettyPrinting().create().toJson(Discordant.config);
-        File file = new File("./config/discordant/config.json");
-        fileWriter(file, gson);
-    }
-
-    public DiscordConfig readDiscordLinkSettings() throws FileNotFoundException {
-        return new Gson().fromJson(new FileReader("./config/discordant/config.json"), DiscordConfig.class);
-    }
-
-
-    public void craftPaths() throws IOException {
-        final var top = Paths.get("./config/discordant");
-        final var linkedProfiles = top.resolve("linked-profiles");
+        final var linkedProfiles = configRoot.resolve("linked-profiles");
         // Why do we need version-specific languages? What do these languages even do?
-        final var languages = top.resolve("languages");
+        final var languages = configRoot.resolve("languages");
         final var languages119 = languages.resolve("1.19");
 
-        Files.createDirectories(top);
+        Files.createDirectories(configRoot);
         Files.createDirectories(linkedProfiles);
         Files.createDirectories(languages);
         Files.createDirectories(languages119);
     }
 
-    @Nullable
-    public static LinkedProfile getLinkedProfile(String uuid) throws IOException {
-        String path = String.format("./config/discordant/linked-profiles/%s.json", uuid);
-        if (Files.exists(Paths.get(path))) {
-            FileReader reader = new FileReader(path);
-            LinkedProfile profile = new Gson().fromJson(reader, LinkedProfile.class);
-            reader.close();
-            return profile;
-        }
-        else {
-            return null;
-        }
+    public DiscordConfig readDiscordLinkSettings() throws FileNotFoundException {
+        return new Gson().fromJson(new FileReader(mainConfigPath.toFile()), DiscordConfig.class);
     }
 
-    public static void saveLinkedProfile(LinkedProfile profile) {
-        String gson = new GsonBuilder().setPrettyPrinting().create().toJson(profile);
-        File file = new File(String.format("./config/discordant/linked-profiles/%s.json", profile.uuid()));
-        fileWriter(file, gson);
-    }
-
-    public static void fileWriter(File file, String gson) {
+    private static void fileWriter(File file, String gson) {
         try {
             file.createNewFile();
         }

--- a/src/main/java/com/kwvanderlinde/discordant/core/config/LinkedProfile.java
+++ b/src/main/java/com/kwvanderlinde/discordant/core/config/LinkedProfile.java
@@ -1,4 +1,0 @@
-package com.kwvanderlinde.discordant.core.config;
-
-public record LinkedProfile(String name, String uuid, String discordId) {
-}

--- a/src/main/java/com/kwvanderlinde/discordant/core/discord/ConfigProfileRepository.java
+++ b/src/main/java/com/kwvanderlinde/discordant/core/discord/ConfigProfileRepository.java
@@ -1,0 +1,72 @@
+package com.kwvanderlinde.discordant.core.discord;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class ConfigProfileRepository implements LinkedProfileRepository {
+    private final Path profileDirectory;
+
+    public ConfigProfileRepository(Path profileDirectory) {
+        this.profileDirectory = profileDirectory;
+    }
+
+    private Path getProfilePath(String uuid) {
+        return this.profileDirectory.resolve(uuid + "json");
+    }
+
+    @Override
+    public @Nullable LinkedProfile get(String uuid) {
+        // TODO Use a type for `uuid` that is definitely path-safe.
+        final var path = getProfilePath(uuid);
+        if (Files.exists(path)) {
+            try (final var reader = new FileReader(path.toFile())) {
+                return new Gson().fromJson(reader, LinkedProfile.class);
+            }
+            catch (IOException e) {
+                return null;
+            }
+        }
+        else {
+            return null;
+        }
+    }
+
+    @Override
+    public void put(LinkedProfile profile) {
+        final var path = getProfilePath(profile.uuid());
+        final var gson = new GsonBuilder().setPrettyPrinting().create().toJson(profile);
+        final var file = path.toFile();
+
+        try {
+            final var created = file.createNewFile();
+            if (!created) {
+                // TODO Report failure.
+            }
+        }
+        catch (IOException e) {
+            // TODO Don't just print a stack trace. Log it!
+            e.printStackTrace();
+        }
+        try (FileWriter writer = new FileWriter(file)) {
+            writer.write(gson);
+        }
+        catch (IOException e) {
+            // TODO Don't just print a stack trace. Log it!
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void delete(String uuid) {
+        final var path = getProfilePath(uuid);
+        final var deleted = path.toFile().delete();
+        if (!deleted) {
+            // TODO Report failure so upstream code can notify that user if needed.
+        }
+    }
+}

--- a/src/main/java/com/kwvanderlinde/discordant/core/discord/JdaDiscordApi.java
+++ b/src/main/java/com/kwvanderlinde/discordant/core/discord/JdaDiscordApi.java
@@ -30,14 +30,14 @@ public class JdaDiscordApi implements DiscordApi {
     // TODO Don't bother. Instead, replace this impl with a dummy impl.
     private boolean stopped = false;
 
-    public JdaDiscordApi(@Nonnull DiscordConfig config) throws InterruptedException {
+    public JdaDiscordApi(@Nonnull DiscordConfig config, @Nonnull LinkedProfileRepository linkedProfileRepository) throws InterruptedException {
         this.config = config;
 
         jda = JDABuilder.createDefault(config.token)
                         .setHttpClient(new OkHttpClient.Builder().build())
                         .setMemberCachePolicy(MemberCachePolicy.ALL)
                         .enableIntents(GatewayIntent.GUILD_MEMBERS)
-                        .addEventListeners(new Object[]{new DiscordListener(this)})
+                        .addEventListeners(new Object[]{new DiscordListener(this, linkedProfileRepository)})
                         .build();
         jda.awaitReady();
 

--- a/src/main/java/com/kwvanderlinde/discordant/core/discord/LinkedProfile.java
+++ b/src/main/java/com/kwvanderlinde/discordant/core/discord/LinkedProfile.java
@@ -1,0 +1,25 @@
+package com.kwvanderlinde.discordant.core.discord;
+
+public class LinkedProfile {
+    private final String name;
+    private final String uuid;
+    private final String discordId;
+
+    public LinkedProfile(String name, String uuid, String discordId) {
+        this.name = name;
+        this.uuid = uuid;
+        this.discordId = discordId;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public String uuid() {
+        return uuid;
+    }
+
+    public String discordId() {
+        return discordId;
+    }
+}

--- a/src/main/java/com/kwvanderlinde/discordant/core/discord/LinkedProfileRepository.java
+++ b/src/main/java/com/kwvanderlinde/discordant/core/discord/LinkedProfileRepository.java
@@ -1,0 +1,13 @@
+package com.kwvanderlinde.discordant.core.discord;
+
+import javax.annotation.Nullable;
+
+public interface LinkedProfileRepository {
+    // TODO Exceptions for failure states.
+
+    @Nullable LinkedProfile get(String uuid);
+
+    void put(LinkedProfile profile);
+
+    void delete(String uuid);
+}

--- a/src/main/java/com/kwvanderlinde/discordant/core/discord/NullLinkedProfileRepository.java
+++ b/src/main/java/com/kwvanderlinde/discordant/core/discord/NullLinkedProfileRepository.java
@@ -1,0 +1,18 @@
+package com.kwvanderlinde.discordant.core.discord;
+
+import org.jetbrains.annotations.Nullable;
+
+public class NullLinkedProfileRepository implements LinkedProfileRepository {
+    @Override
+    public @Nullable LinkedProfile get(String uuid) {
+        return null;
+    }
+
+    @Override
+    public void put(LinkedProfile profile) {
+    }
+
+    @Override
+    public void delete(String uuid) {
+    }
+}

--- a/src/main/java/com/kwvanderlinde/discordant/mc/ProfileLinkCommand.java
+++ b/src/main/java/com/kwvanderlinde/discordant/mc/ProfileLinkCommand.java
@@ -1,7 +1,7 @@
 package com.kwvanderlinde.discordant.mc;
 
 import com.kwvanderlinde.discordant.core.config.ConfigManager;
-import com.kwvanderlinde.discordant.core.config.LinkedProfile;
+import com.kwvanderlinde.discordant.core.discord.LinkedProfile;
 import com.kwvanderlinde.discordant.mc.discord.DiscordConfig;
 import com.kwvanderlinde.discordant.mc.discord.Discordant;
 import com.kwvanderlinde.discordant.mc.discord.VerificationData;
@@ -60,11 +60,11 @@ public class ProfileLinkCommand {
 
     private static int unlink(CommandSourceStack source) throws CommandSyntaxException, IOException {
         String id = source.getPlayerOrException().getStringUUID();
-        LinkedProfile profile = ConfigManager.getLinkedProfile(id);
+        LinkedProfile profile = Discordant.linkedProfileRepository.get(id);
         if (profile != null) {
             Discordant.linkedPlayersByDiscordId.remove(profile.discordId());
             Discordant.linkedPlayers.remove(id);
-            Files.delete(Paths.get(String.format("./config/discordant/linked-profiles/%s.json", id)));
+            Discordant.linkedProfileRepository.delete(id);
             source.sendSuccess(Component.literal(Discordant.config.codeUnlinkMsg), false);
         }
         else {

--- a/src/main/java/com/kwvanderlinde/discordant/mc/discord/DiscordConfig.java
+++ b/src/main/java/com/kwvanderlinde/discordant/mc/discord/DiscordConfig.java
@@ -46,6 +46,7 @@ public class DiscordConfig {
     public transient String cLinkMsg2 = "";
 
     public void setup() {
+        // TODO I am not a fan of my config objects having much logic in them, definitely not a required extra method call!
         String msg = commandLinkMsg;
         int i = msg.indexOf("{code}");
         if (i != -1) {

--- a/src/main/java/com/kwvanderlinde/discordant/mc/mixin/PlayerListMixins.java
+++ b/src/main/java/com/kwvanderlinde/discordant/mc/mixin/PlayerListMixins.java
@@ -1,7 +1,7 @@
 package com.kwvanderlinde.discordant.mc.mixin;
 
 import com.kwvanderlinde.discordant.core.config.ConfigManager;
-import com.kwvanderlinde.discordant.core.config.LinkedProfile;
+import com.kwvanderlinde.discordant.core.discord.LinkedProfile;
 import com.kwvanderlinde.discordant.mc.discord.DiscordConfig;
 import com.kwvanderlinde.discordant.mc.discord.Discordant;
 import com.kwvanderlinde.discordant.mc.discord.VerificationData;
@@ -48,7 +48,7 @@ public class PlayerListMixins {
         String uuid = gameProfile.getId().toString();
         LinkedProfile profile = null;
         if (cfg.enableAccountLinking) {
-            profile = ConfigManager.getLinkedProfile(uuid);
+            profile = Discordant.linkedProfileRepository.get(uuid);
             if (profile != null) {
                 Discordant.linkedPlayers.put(uuid, profile);
                 Discordant.linkedPlayersByDiscordId.put(profile.discordId(), gameProfile.getName());


### PR DESCRIPTION
`LinkedProfile`s are now managed by a `LinkedProfileRepository`. While they are still stored under the `discordant/` config directory, that can be considered and implementation detail and thus the `ConfigManager` does not care. In the future, `ConfigManager` can manage a dedicated `discordant/config/` directory as we expand the number of configuration files. The `LinkedProfile` `record` has to be converted back to a `class` as Gson was unable to set the fields, even though it can set the `final` fields of a `class`... confusing.

`ConfigManager` is now simpler in that the number of public methods has been reduced. `craftPaths()` and `genDiscordLinkSettings()` have been merged into a single method `ensureConfigStructure()`, and no support for linked profiles remains. Instead of operating on a mixture of `Path`, `String` and `new File(...)`, we now always represent paths as `Path`s and convert those to `File`s by `Path::toFile()`.