### PR TITLE
Add free-form avatar URLs that can be embedded into messages.

### DIFF
--- a/src/main/java/com/kwvanderlinde/discordant/core/Discordant.java
+++ b/src/main/java/com/kwvanderlinde/discordant/core/Discordant.java
@@ -162,7 +162,7 @@ public class Discordant {
             final var message = config.discord.messages.playerChat
                     .instantiate(new ChatScope(
                             // TODO Look up the linked profile and pass the corresponding discord user.
-                            new PlayerScope(player, null, getPlayerIconUrl(player)),
+                            new PlayerScope(player, null, getPlayerIconUrl(player), getAvatarUrls(player)),
                             chatMessage
                     ));
             final var e = buildMessageEmbed(message);
@@ -214,7 +214,7 @@ public class Discordant {
 
             // TODO Look up the linked profile and pass the corresponding discord user.
             final var message = config.discord.messages.playerJoin
-                    .instantiate(new PlayerScope(player, null, getPlayerIconUrl(player)));
+                    .instantiate(new PlayerScope(player, null, getPlayerIconUrl(player), getAvatarUrls(player)));
 
             discordApi.sendEmbed(buildMessageEmbed(message).build());
         });
@@ -225,7 +225,7 @@ public class Discordant {
 
             // TODO Look up the linked profile and pass the corresponding discord user.
             final var message = config.discord.messages.playerLeave
-                    .instantiate(new PlayerScope(player, null, getPlayerIconUrl(player)));
+                    .instantiate(new PlayerScope(player, null, getPlayerIconUrl(player), getAvatarUrls(player)));
             discordApi.sendEmbed(buildMessageEmbed(message).build());
 
             knownPlayerIds.remove(player.uuid());
@@ -239,7 +239,7 @@ public class Discordant {
         minecraftIntegration.events().onPlayerDeath((player, deathMessage) -> {
             final var message = config.discord.messages.playerDeath
                     .instantiate(new DeathScope(
-                            new PlayerScope(player, null, getPlayerIconUrl(player)),
+                            new PlayerScope(player, null, getPlayerIconUrl(player), getAvatarUrls(player)),
                             deathMessage
                     ));
             discordApi.sendEmbed(buildMessageEmbed(message).build());
@@ -248,7 +248,7 @@ public class Discordant {
             // TODO Look up the linked profile and pass the corresponding discord user.
             final var message = config.discord.messages.playerAdvancement
                     .instantiate(new AdvancementScope(
-                            new PlayerScope(player, null, getPlayerIconUrl(player)),
+                            new PlayerScope(player, null, getPlayerIconUrl(player), getAvatarUrls(player)),
                             advancement
                     ));
             discordApi.sendEmbed(buildMessageEmbed(message).build());
@@ -326,7 +326,7 @@ public class Discordant {
                 }
             };
             final var message = config.discord.messages.successfulVerification
-                    .instantiate(new PlayerScope(player, author, getPlayerIconUrl(player)));
+                    .instantiate(new PlayerScope(player, author, getPlayerIconUrl(player), getAvatarUrls(player)));
             discordApi.sendEmbed(channelToRespondIn, buildMessageEmbed(message).build());
 
             final var logMessage = String.format("Successfully linked discord account %s to minecraft account %s (%s)",
@@ -344,7 +344,7 @@ public class Discordant {
                 Member m = guild.getMemberById(profile.discordId());
                 final var player = minecraftIntegration.getServer().getPlayer(profile.uuid());
                 final var message = config.discord.messages.alreadyLinked
-                        .instantiate(new PlayerScope(player, m == null ? null : m.getUser(), getPlayerIconUrl(player)));
+                        .instantiate(new PlayerScope(player, m == null ? null : m.getUser(), getPlayerIconUrl(player), getAvatarUrls(player)));
                 discordApi.sendEmbed(channelToRespondIn, buildMessageEmbed(message).build());
                 pendingPlayersUUID.remove(id);
                 pendingPlayers.remove(code);
@@ -398,10 +398,21 @@ public class Discordant {
     }
 
     private String getPlayerIconUrl(Player player) {
-        final var result = config.playerHeadsUrl
+        return config.playerIconUrl
                 .replaceAll("\\{username}", player.name())
                 .replaceAll("\\{uuid}", player.uuid().toString())
                 .replaceAll("\\{time}", String.valueOf(currentTime));
+    }
+
+    private Map<String, String> getAvatarUrls(Player player) {
+        final var result = new HashMap<String, String>();
+        for (final var entry : config.avatarUrls.entrySet()) {
+            final var url = entry.getValue()
+                                 .replaceAll("\\{username}", player.name())
+                                 .replaceAll("\\{uuid}", player.uuid().toString())
+                                 .replaceAll("\\{time}", String.valueOf(currentTime));
+            result.put(entry.getKey(), url);
+        }
         return result;
     }
 

--- a/src/main/java/com/kwvanderlinde/discordant/core/Discordant.java
+++ b/src/main/java/com/kwvanderlinde/discordant/core/Discordant.java
@@ -116,6 +116,13 @@ public class Discordant {
             final var message = config.discord.messages.serverStart
                     .instantiate(new ServerScope(server, config.minecraft.serverName));
             discordApi.sendEmbed(buildMessageEmbed(message).build());
+
+            // Update the channel topic.
+            final var topic = config.discord.topics.channelTopic
+                    .instantiate(new ServerScope(server, config.minecraft.serverName));
+            if (topic.description != null) {
+                discordApi.setTopic(topic.description);
+            }
         });
         minecraftIntegration.events().onServerStopping((server) -> {
             shutdown();

--- a/src/main/java/com/kwvanderlinde/discordant/core/config/ConfigManager.java
+++ b/src/main/java/com/kwvanderlinde/discordant/core/config/ConfigManager.java
@@ -30,6 +30,7 @@ public class ConfigManager {
         this.mainConfigPath = configRoot.resolve("config.json");
         this.gson = new GsonBuilder().setPrettyPrinting()
                                      .serializeNulls()
+                                     .disableHtmlEscaping()
                                      .registerTypeAdapter(Color.class, new ColorAdapter())
                                      .create();
     }

--- a/src/main/java/com/kwvanderlinde/discordant/core/config/DiscordMessagesConfig.java
+++ b/src/main/java/com/kwvanderlinde/discordant/core/config/DiscordMessagesConfig.java
@@ -9,12 +9,12 @@ import com.kwvanderlinde.discordant.core.messages.scopes.ServerScope;
 import java.awt.Color;
 
 public class DiscordMessagesConfig {
-    public DiscordMessageConfig<ServerScope> serverStart = new DiscordMessageConfig<>("{server.name} started", new Color(0x00ff00), null, "> _{server.motd}_");
+    public DiscordMessageConfig<ServerScope> serverStart = new DiscordMessageConfig<>("{server.name} started", new Color(0x00ff00), null, "_{server.motd}_");
     public DiscordMessageConfig<ServerScope> serverStop = new DiscordMessageConfig<>("{server.name} stopped", new Color(0xff0000), null, null);
-    public DiscordMessageConfig<PlayerScope> playerJoin = new DiscordMessageConfig<>("Player joined", new Color(0x00ff00), "{player.iconUrl}", "{username} joined the server!");
+    public DiscordMessageConfig<PlayerScope> playerJoin = new DiscordMessageConfig<>("Player joined", new Color(0x00ff00), "{player.avatarUrls|body}", "{username} joined the server!");
     public DiscordMessageConfig<PlayerScope> playerLeave = new DiscordMessageConfig<>("Player left", new Color(0xff0000), null, "{username} left the server!");
-    public DiscordMessageConfig<AdvancementScope> playerAdvancement = new DiscordMessageConfig<>("{player.name} has completed the challenge {advancement.title}", new Color(0xBF1AED), "{player.iconUrl}", "{advancement.description}");
-    public DiscordMessageConfig<DeathScope> playerDeath = new DiscordMessageConfig<>("The unthinkable has happened", new Color(0x000000), "{player.iconUrl}", "{death.message}");
+    public DiscordMessageConfig<AdvancementScope> playerAdvancement = new DiscordMessageConfig<>("{player.name} has completed the challenge {advancement.title}", new Color(0xBF1AED), "{player.avatarUrls|head}", "{advancement.description}");
+    public DiscordMessageConfig<DeathScope> playerDeath = new DiscordMessageConfig<>("The unthinkable has happened", new Color(0x000000), "{player.avatarUrls|head}", "{death.message}");
     public DiscordMessageConfig<ChatScope> playerChat = new DiscordMessageConfig<>(null, new Color(0x00ffff), null, "{chat.message}");
     public DiscordMessageConfig<PlayerScope> successfulVerification = new DiscordMessageConfig<>("Account linking successful!", new Color(0x92D22E), null, "Successfully linked discord account to your game account {username}({uuid})");
     public DiscordMessageConfig<PlayerScope> alreadyLinked = new DiscordMessageConfig<>("Account already linked", new Color(0x992D22), null, "Game account {username} is already linked to {discordname}");

--- a/src/main/java/com/kwvanderlinde/discordant/core/config/DiscordTopicsConfig.java
+++ b/src/main/java/com/kwvanderlinde/discordant/core/config/DiscordTopicsConfig.java
@@ -3,6 +3,6 @@ package com.kwvanderlinde.discordant.core.config;
 import com.kwvanderlinde.discordant.core.messages.scopes.ServerScope;
 
 public class DiscordTopicsConfig {
-    public TopicConfig<ServerScope> channelTopic = new TopicConfig<>("Players online: {server.playerCount} / {server.maxPlayerCount}");
+    public TopicConfig<ServerScope> channelTopic = new TopicConfig<>("Players online: {server.playerCount} / {server.maxPlayerCount} | Thank you to Crafatar for providing avatars: https://crafatar.com");
     public TopicConfig<ServerScope> shutdownTopic = new TopicConfig<>("Server offline");
 }

--- a/src/main/java/com/kwvanderlinde/discordant/core/config/DiscordantConfig.java
+++ b/src/main/java/com/kwvanderlinde/discordant/core/config/DiscordantConfig.java
@@ -1,9 +1,11 @@
 package com.kwvanderlinde.discordant.core.config;
 
+import java.util.Map;
+
 public class DiscordantConfig {
     public boolean enableLogsForwarding = true;
 
-    public String playerHeadsUrl = "http://cravatar.eu/avatar/{uuid}/400.png";
+    public String playerIconUrl = "https://crafatar.com/avatars/{uuid}/?size=16&overlay&ts={time}";
     public boolean enableAccountLinking = true;
     public boolean forceLinking = false;
     public boolean enableMentions = true;
@@ -11,7 +13,11 @@ public class DiscordantConfig {
     public String targetLocalization = "en_us";
     public boolean isBidirectional = false;
 
-    // TODO Make the new types initialize to reasonable defaults in the absence of deserialization.
+    public Map<String, String> avatarUrls = Map.of(
+            "head", "https://crafatar.com/renders/head/{uuid}/?scale=10&overlay&ts={time}",
+            "body", "https://crafatar.com/renders/body/{uuid}/?scale=10&overlay&ts={time}"
+    );
+
     public DiscordConfig discord = new DiscordConfig();
     public MinecraftConfig minecraft = new MinecraftConfig();
 }

--- a/src/main/java/com/kwvanderlinde/discordant/core/discord/api/JdaDiscordApi.java
+++ b/src/main/java/com/kwvanderlinde/discordant/core/discord/api/JdaDiscordApi.java
@@ -72,7 +72,8 @@ public class JdaDiscordApi implements DiscordApi {
     @Override
     public void close() {
         stopped = true;
-        jda.shutdown();
+        // Don't let JDA hold things up, it's not worth it.
+        jda.shutdownNow();
     }
 
     @Override

--- a/src/main/java/com/kwvanderlinde/discordant/core/messages/ScopeUtil.java
+++ b/src/main/java/com/kwvanderlinde/discordant/core/messages/ScopeUtil.java
@@ -6,7 +6,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 public class ScopeUtil {
-    private static final Pattern parameterPattern = Pattern.compile("\\{([a-zA-Z.]*)}");
+    private static final Pattern parameterPattern = Pattern.compile("\\{([a-zA-Z.|]*)}");
 
     public static SemanticMessage instantiate(String template, Map<String, SemanticMessage.Part> values) {
         final var result = new SemanticMessage();

--- a/src/main/java/com/kwvanderlinde/discordant/core/messages/scopes/PlayerScope.java
+++ b/src/main/java/com/kwvanderlinde/discordant/core/messages/scopes/PlayerScope.java
@@ -5,17 +5,19 @@ import com.kwvanderlinde.discordant.core.modinterfaces.Player;
 import net.dv8tion.jda.api.entities.User;
 
 import javax.annotation.Nullable;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public record PlayerScope(Player player, @Nullable User discordUser, String iconUrl) implements Scope<PlayerScope> {
+public record PlayerScope(Player player, @Nullable User discordUser, String iconUrl, Map<String, String> avatarUrls) implements Scope<PlayerScope> {
     public static List<String> parameters() {
         return List.of("uuid", "username", "player.uuid", "player.name", "discordid", "discordname", "discordtag", "player.iconUrl");
     }
 
     @Override
     public Map<String, SemanticMessage.Part> values() {
-        return Map.of(
+        final var result = new HashMap<String, SemanticMessage.Part>();
+        result.putAll(Map.of(
                 "uuid", SemanticMessage.literal(player.uuid().toString()),
                 "username", SemanticMessage.literal(player.name()),
                 "player.uuid", SemanticMessage.literal(player.uuid().toString()),
@@ -24,6 +26,11 @@ public record PlayerScope(Player player, @Nullable User discordUser, String icon
                 "discordname", discordUser == null ? SemanticMessage.literal("") : SemanticMessage.literal(discordUser.getName()),
                 "discordtag", discordUser == null ? SemanticMessage.literal("") : SemanticMessage.literal(discordUser.getAsTag()),
                 "player.iconUrl", SemanticMessage.literal(iconUrl)
-        );
+        ));
+        for (final var entry : avatarUrls.entrySet()) {
+            result.put("player.avatarUrls|" + entry.getKey(), SemanticMessage.literal(entry.getValue()));
+        }
+
+        return result;
     }
 }


### PR DESCRIPTION
The avatars are specifies as keys in the `"avatarUrls"` object and the values function just like the player icon
URL. Messages can reference any of these by using the `{player.avatarUrls|<key>}` in addition to being able to use
`{player.iconUrl}`.

The reason for keeping `{player.iconUrl}` is that we want a flat face always available for use as author icons in
Discord messages.

The default URLs for player icons and avatars has been changed from cravatar.eu to crafatar.com. Acknowledgement has
been added to the default channel topic.

The generated `config.json` has been tweaked to no longer do HTML escaping as that just adds noise.